### PR TITLE
FIX: CSP issue, anonymous webinar visibility

### DIFF
--- a/app/controllers/webinars_controller.rb
+++ b/app/controllers/webinars_controller.rb
@@ -4,7 +4,7 @@ module Zoom
   class WebinarsController < ApplicationController
     skip_before_action :verify_authenticity_token, only: [:register]
     skip_before_action :check_xhr, only: [:sdk]
-    before_action :ensure_logged_in
+    before_action :ensure_logged_in, except: [:show]
     before_action :ensure_webinar_exists, only: [ :show, :destroy, :add_panelist,
                                                   :remove_panelist, :register, :unregister,
                                                   :signature, :sdk, :update_nonzoom_host, :update_nonzoom_details ]
@@ -153,9 +153,9 @@ module Zoom
     def signature
       sig = Zoom::Webinars.new(Zoom::Client.new).signature(webinar.zoom_id)
       if SiteSetting.zoom_send_user_id
-        username = "#{current_user.name} (#{current_user.id})"
+        username = "#{current_user.name || current_user.username} (#{current_user.id})"
       else
-        username = current_user.name
+        username = current_user.name || current_user.username
       end
 
       render json: {

--- a/assets/javascripts/discourse/initializers/composer-toolbar-webinar-button.js.es6
+++ b/assets/javascripts/discourse/initializers/composer-toolbar-webinar-button.js.es6
@@ -9,20 +9,20 @@ function initializeWebinarButton(api) {
       showWebinarModal() {
         showModal("webinar-picker", {
           model: this.model,
-          title: "zoom.webinar_picker.title"
+          title: "zoom.webinar_picker.title",
         });
-      }
-    }
+      },
+    },
   });
 
-  api.addToolbarPopupMenuOptionsCallback(controller => {
+  api.addToolbarPopupMenuOptionsCallback((controller) => {
     const composer = controller.model;
     if (composer && composer.creatingTopic) {
       return {
         id: "associate_webinar_button",
         icon: "video",
         action: "showWebinarModal",
-        label: "zoom.webinar_picker.button"
+        label: "zoom.webinar_picker.button",
       };
     }
   });
@@ -37,5 +37,5 @@ export default {
     if (siteSettings.zoom_enabled && currentUser) {
       withPluginApi("0.5", initializeWebinarButton);
     }
-  }
+  },
 };

--- a/assets/javascripts/discourse/initializers/zoom-composer.js.es6
+++ b/assets/javascripts/discourse/initializers/zoom-composer.js.es6
@@ -13,13 +13,13 @@ export default {
       "zoomWebinarStartDate"
     );
 
-    withPluginApi("0.8.31", api => {
-      api.decorateWidget("post:before", dec => {
+    withPluginApi("0.8.31", (api) => {
+      api.decorateWidget("post:before", (dec) => {
         if (dec.canConnectComponent && dec.attrs.firstPost) {
           if (!dec.attrs.cloaked) {
             return dec.connect({
               component: "post-top-webinar",
-              context: "model"
+              context: "model",
             });
           }
         }
@@ -36,8 +36,8 @@ export default {
           } else {
             document.querySelector("body").classList.remove("has-webinar");
           }
-        }
+        },
       });
     });
-  }
+  },
 };

--- a/assets/javascripts/discourse/templates/components/webinar.hbs
+++ b/assets/javascripts/discourse/templates/components/webinar.hbs
@@ -52,7 +52,9 @@
       </div>
     {{/if}}
 
-    {{webinar-register webinar=webinar showCalendarButtons=true}}
+    {{#if currentUser}}
+      {{webinar-register webinar=webinar showCalendarButtons=true}}
+    {{/if}}
 
     {{#if webinarEnded}}
       <div class="event-ended">
@@ -85,7 +87,11 @@
       {{/if}}
       {{#unless webinarStarted}}
         <div class="webinar-footnote">
-          {{i18n "zoom.webinar_footnote"}}
+          {{#if currentUser}}
+            {{i18n "zoom.webinar_footnote"}}
+          {{else}}
+            {{i18n "zoom.webinar_logged_in_users_only"}}
+          {{/if}}
         </div>
       {{/unless}}
     {{/if}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -51,6 +51,7 @@ en:
       add_to_outlook: "Add to Outlook"
       add_to_calendar: "Add to Calendar"
       webinar_footnote: "Can't make the event? Register and we'll send you a post-event recap."
+      webinar_logged_in_users_only: "Webinar registration is only accessible to logged-in users."
       add_past_webinar: "Add past webinar"
       past_label: "Past webinar title"
       past_date: "Past webinar date"

--- a/plugin.rb
+++ b/plugin.rb
@@ -114,18 +114,23 @@ after_initialize do
 
   # CSP overrides to the SDK endpoint only
   ZOOM_SDK_REGEX = /webinars\/(.*)\/sdk$/
-  ZOOM_SDK_CSP = [
+  ZOOM_SDK_SCRIPT_SRC = [
     :unsafe_eval,
     :unsafe_inline,
     "https://source.zoom.us",
     "https://zoom.us"
   ]
+  ZOOM_SDK_WORKER_SRC = [
+    "blob:"
+  ]
+
 
   module ContentSecurityPolicyExtensionZoomPluginPatch
     def path_specific_extension(path_info)
       obj = super
       if ZOOM_SDK_REGEX.match?(path_info)
-        (obj[:script_src] ||= []).concat(ZOOM_SDK_CSP)
+        (obj[:script_src] ||= []).concat(ZOOM_SDK_SCRIPT_SRC)
+        (obj[:worker_src] ||= []).concat(ZOOM_SDK_WORKER_SRC)
       end
       obj
     end

--- a/spec/requests/webinars_controller_spec.rb
+++ b/spec/requests/webinars_controller_spec.rb
@@ -10,6 +10,16 @@ describe Zoom::WebinarsController do
   fab!(:topic) { Fabricate(:topic, user: user) }
   let(:webinar) { Webinar.create(topic: topic, zoom_id: "123") }
 
+  describe "#show" do
+    it "works for anons" do
+      get "/zoom/webinars/#{webinar.id}.json"
+      json = JSON.parse(response.body)
+
+      expect(response.status).to eq(200)
+      expect(json["webinar"]["topic_id"]).to eq(topic.id)
+    end
+  end
+
   describe "#destroy" do
     it "requires the user to be logged in" do
       delete("/zoom/webinars/#{webinar.id}.json")


### PR DESCRIPTION
The Zoom SDK endpoint requires a modification to the CSP, Zoom recently
started using a service worker via `blob:`, so that needs to be allowed.

I also noticed that the whole webinar block is hidden to anonymous
users, it makes sense to show that section, even though users need
accounts to register/join a webinar event.

Another fix included here: we need to pass something to the Zoom SDK for
"username", so if names are empty, usernames are used.