### PR TITLE
DEV: Change settings root from plugins: to discourse_zoom

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_zoom: "Discourse Zoom"
   site_settings:
     zoom_enabled: "Zoom plugin enabled"
     zoom_send_reminder_minutes_before_webinar: "How many minutes before a webinar starts, do you want reminder notifications sent to attendees? Set to empty or 0 if you do not want notifications sent."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_zoom:
   zoom_enabled:
     default: false
     client: true


### PR DESCRIPTION
This is so the plugins settings are better categorized in the site settings UI.