### PR TITLE
FEATURE: Add Zoom description and location to Google Calendar

### DIFF
--- a/assets/javascripts/discourse/components/webinar-register.js
+++ b/assets/javascripts/discourse/components/webinar-register.js
@@ -120,7 +120,11 @@ export default Component.extend({
       webinar.title
     )}&dates=${this.formatDateForGoogleApi(
       webinar.starts_at
-    )}/${this.formatDateForGoogleApi(webinar.ends_at)}`;
+    )}/${this.formatDateForGoogleApi(
+      webinar.ends_at
+    )}&details=${encodeURIComponent(
+      this.formatDescriptionForGoogleApi(webinar.join_url)
+    )}&location=${encodeURIComponent(webinar.join_url)}`;
   },
 
   @discourseComputed("webinar.{starts_at,ends_at}")
@@ -152,6 +156,11 @@ export default Component.extend({
 
   formatDateForGoogleApi(date) {
     return new Date(date).toISOString().replace(/-|:|\.\d\d\d/g, "");
+  },
+
+  formatDescriptionForGoogleApi(joinUrl) {
+    return `Join from a PC, Mac, iPad, iPhone or Android device:
+    Please click this URL to join. <a href="${joinUrl}">${joinUrl}</a>`;
   },
 
   formatDateForIcs(date) {

--- a/test/javascripts/integration/components/webinar-register-test.js
+++ b/test/javascripts/integration/components/webinar-register-test.js
@@ -1,0 +1,34 @@
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+
+module("Integration | Component | webinar-register", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("Google Calendar link", async function (assert) {
+    const webinar = {
+      id: 99,
+      title: "Spider Webinar",
+      status: "scheduled",
+      ends_at: "2031-09-01T12:00:00Z",
+      starts_at: "2031-09-01T11:00:00Z",
+      attendees: [{ id: 1 }],
+      panelists: [{ id: 1 }],
+      host: { id: 101 },
+      join_url: "https://zoom.us/j/123456789",
+    };
+    this.set("webinar", webinar);
+    this.currentUser.id = 101;
+
+    await render(hbs`
+      <WebinarRegister @webinar={{this.webinar}} @showCalendarButtons={{true}}/>
+    `);
+    assert
+      .dom(".zoom-add-to-calendar-container a")
+      .hasAttribute(
+        "href",
+        "http://www.google.com/calendar/event?action=TEMPLATE&text=Spider%20Webinar&dates=20310901T110000Z/20310901T120000Z&details=Join%20from%20a%20PC%2C%20Mac%2C%20iPad%2C%20iPhone%20or%20Android%20device%3A%0A%20%20%20%20Please%20click%20this%20URL%20to%20join.%20%3Ca%20href%3D%22https%3A%2F%2Fzoom.us%2Fj%2F123456789%22%3Ehttps%3A%2F%2Fzoom.us%2Fj%2F123456789%3C%2Fa%3E&location=https%3A%2F%2Fzoom.us%2Fj%2F123456789"
+      );
+  });
+});


### PR DESCRIPTION
When a user clicks on the "Add to Google Calendar" button 👇  it opens Google Calendar with pre-filled values.

<img width="300" alt="Screenshot 2024-09-07 at 12 57 39 AM" src="https://github.com/user-attachments/assets/98a82cf0-7236-4fc9-84e6-e8757d9becc5">

This PR adds the zoom meeting to description, and this is what it will look like 👇 

<img width="300" alt="Screenshot 2024-09-07 at 12 55 34 AM" src="https://github.com/user-attachments/assets/b891a92c-c134-412c-bf23-8bae228de75e">

For reference, this is what <https://zoom.us/webinar/list/#/upcoming> will show when you click on Google Calendar:
<img width="300" alt="zoom-cal-1" src="https://github.com/user-attachments/assets/be22991d-e9a4-4214-a8ff-e13761038e18">

