### PR TITLE
DEV: Improve error logging

### DIFF
--- a/app/services/problem_check/s2s_webinar_subscription.rb
+++ b/app/services/problem_check/s2s_webinar_subscription.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ProblemCheck::S2sWebinarSubscription < ProblemCheck::InlineProblemCheck
+  self.priority = "high"
+end

--- a/assets/javascripts/discourse/components/modal/webinar-picker.gjs
+++ b/assets/javascripts/discourse/components/modal/webinar-picker.gjs
@@ -65,7 +65,7 @@ export default class WebinarPicker extends Component {
     } catch (error) {
       this.webinar = null;
       this.selected = false;
-      this.error = true;
+      this.error = error.jqXHR.responseJSON.errors[0];
     } finally {
       this.loading = false;
     }
@@ -250,7 +250,7 @@ export default class WebinarPicker extends Component {
           {{else}}
             {{#if this.error}}
               <div class="alert alert-error">
-                {{i18n "zoom.error"}}
+                {{this.error}}
               </div>
             {{/if}}
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -22,6 +22,13 @@ en:
             zoom_id:
               webinar_in_use: "Another topic is already associated with this webinar."
 
+  zoom_plugin_errors:
+    s2s_oauth_authorization: "OAuth app is not authorized to make this request"
+
+  dashboard:
+    problem:
+      s2s_webinar_subscription: "Zooom Plugin: Webinar plan is missing. You must suscribe to the webinar plan to have access to this feature"
+
   system_messages:
     webinar_reminder:
       title: "Upcoming Webinar"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -25,10 +25,11 @@ en:
   zoom_plugin_errors:
     s2s_oauth_authorization: "OAuth app is not authorized to make this request"
     meeting_not_found: "Meeting not found or has expired"
+    contact_system_admin: "There has been a problem, please contact an Administrator"
 
   dashboard:
     problem:
-      s2s_webinar_subscription: "Zooom Plugin: Webinar plan is missing. You must suscribe to the webinar plan to have access to this feature"
+      s2s_webinar_subscription: "Zoom Plugin: Webinar plan is missing. You must subscribe to the webinar plan to have access to this feature"
 
   system_messages:
     webinar_reminder:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -24,6 +24,7 @@ en:
 
   zoom_plugin_errors:
     s2s_oauth_authorization: "OAuth app is not authorized to make this request"
+    meeting_not_found: "Meeting not found or has expired"
 
   dashboard:
     problem:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -25,7 +25,7 @@ en:
   zoom_plugin_errors:
     s2s_oauth_authorization: "OAuth app is not authorized to make this request"
     meeting_not_found: "Meeting not found or has expired"
-    contact_system_admin: "There has been a problem, please contact an Administrator"
+    contact_system_admin: "The Webinar plan is required for this site's Zoom subscription. Please <a href='%{base_url}/about'>contact your administrators</a>."
 
   dashboard:
     problem:

--- a/lib/oauth_client.rb
+++ b/lib/oauth_client.rb
@@ -72,6 +72,7 @@ module Zoom
 
       if response&.body.present?
         result = JSON.parse(response.body)
+        meeting_not_found if (response.status) == 404 && result["code"] == 3001
         log("Zoom verbose log:\n API result = #{result.inspect}")
       end
       response
@@ -120,6 +121,13 @@ module Zoom
               "zoom_plugin_errors",
               SiteSetting.s2s_oauth_token,
               custom_message: "zoom_plugin_errors.#{custom_message}",
+            )
+    end
+
+    def meeting_not_found
+      raise Discourse::NotFound.new(
+              I18n.t("zoom_plugin_errors.meeting_not_found"),
+              custom_message: "zoom_plugin_errors.meeting_not_found",
             )
     end
   end

--- a/lib/oauth_client.rb
+++ b/lib/oauth_client.rb
@@ -67,7 +67,7 @@ module Zoom
           authorization_invalid("contact_system_admin")
         end
 
-        authorization_invalid("contact_system_admin")
+        authorization_invalid
       end
 
       log("Zoom verbose log:\n API error = #{response.inspect}") if response.status != 200

--- a/lib/oauth_client.rb
+++ b/lib/oauth_client.rb
@@ -63,9 +63,11 @@ module Zoom
               message: response.body[:message],
             },
           )
+
+          authorization_invalid("contact_system_admin")
         end
 
-        authorization_invalid
+        authorization_invalid("contact_system_admin")
       end
 
       log("Zoom verbose log:\n API error = #{response.inspect}") if response.status != 200
@@ -115,7 +117,7 @@ module Zoom
     end
 
     def authorization_invalid(custom_message = nil)
-      custom_message = "s2s_oauth_authorization" if @oauth
+      custom_message = "s2s_oauth_authorization" if @oauth && !custom_message
 
       raise Discourse::InvalidAccess.new(
               "zoom_plugin_errors",

--- a/plugin.rb
+++ b/plugin.rb
@@ -17,6 +17,8 @@ register_svg_icon "far-calendar-alt"
 register_svg_icon "video"
 
 after_initialize do
+  require_relative "app/services/problem_check/s2s_webinar_subscription.rb"
+  register_problem_check ProblemCheck::S2sWebinarSubscription
   module ::Zoom
     PLUGIN_NAME ||= "discourse-zoom".freeze
 

--- a/spec/requests/oauth_spec.rb
+++ b/spec/requests/oauth_spec.rb
@@ -39,7 +39,7 @@ describe Zoom::OAuthClient do
             Authorization: "Bearer not_a_valid_token",
             Host: "api.zoom.us",
           },
-        ).to_return(status: 400)
+        ).to_return(body: ZoomApiStubs.get_webinar(user.id), status: 400)
       end
       describe "valid/present" do
         before { SiteSetting.s2s_oauth_token = valid_token }
@@ -91,7 +91,7 @@ describe Zoom::OAuthClient do
               headers: {
                 content_type: "application/json",
               },
-              status: 200,
+              status: 400,
             )
           end
           it "can't request a new oauth_token" do

--- a/spec/requests/webinars_controller_spec.rb
+++ b/spec/requests/webinars_controller_spec.rb
@@ -376,4 +376,72 @@ describe Zoom::WebinarsController do
       expect(response.headers["Content-Security-Policy"]).to include("'unsafe-eval'")
     end
   end
+
+  describe "#preview" do
+    context "when Webinar plan missing" do
+      before do
+        stub_request(:get, "https://api.zoom.us/v2/webinars/#{webinar.id}").with(
+          headers: {
+            "Authorization" => "Bearer Test_Token",
+            "Content-Type" => "application/json",
+            "Host" => "api.zoom.us",
+          },
+        ).to_return(
+          { status: 401, body: { "code" => 200, "message" => "Webinar plan is missing." }.to_json },
+          { status: 401, body: { "code" => 200, "message" => "Webinar plan is missing." }.to_json },
+        )
+
+        stub_request(:get, "https://api.zoom.us/v2/webinars/#{webinar.id}/panelists").to_return(
+          status: 201,
+          body: { panelists: [{ id: "123", email: user.email }] }.to_json,
+        )
+
+        stub_request(
+          :post,
+          "https://zoom.us/oauth/token?account_id=&grant_type=account_credentials",
+        ).with(
+          headers: {
+            "Authorization" => "Basic  Og==",
+            "Content-Type" => "application/json",
+            "Host" => "zoom.us",
+          },
+        ).to_return(
+          {
+            body: { access_token: "token" }.to_json,
+            headers: {
+              content_type: "application/json",
+            },
+            status: 200,
+          },
+          {
+            body: { access_token: "token" }.to_json,
+            headers: {
+              content_type: "application/json",
+            },
+            status: 200,
+          },
+        )
+
+        stub_request(:get, "https://api.zoom.us/v2/webinars/#{webinar.id}").with(
+          headers: {
+            "Authorization" => "Bearer token",
+            "Content-Type" => "application/json",
+            "Host" => "api.zoom.us",
+          },
+        ).to_return(
+          { status: 401, body: { "code" => 200, "message" => "Webinar plan is missing." }.to_json },
+        )
+
+        sign_in(user)
+      end
+      it "creates problem check error" do
+        get "/zoom/webinars/#{webinar.id}/preview.json"
+
+        expect(response.status).to eq(403)
+        expect(AdminNotice.problem.last.message).to eq(
+          I18n.t("dashboard.problem.s2s_webinar_subscription", message: "Webinar plan is missing."),
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Description**
As part of an update for this plugin we have decided to improve error output. Here we address these two type of errors and also improves how errors are displayed in general

404 {"code":3001,"message":"Meeting is not found or has expired."}
400 {"code":200,"message":"Webinar plan is missing .... } 

Example of improved error logging 

![imagen](https://github.com/user-attachments/assets/0616938a-3255-4c53-8668-bf670f2972e1)
