### PR TITLE
DEV: resolve Rails/ReversibleMigrationMethodDefinition errors

### DIFF
--- a/db/migrate/20200114171405_drop_webinar_users_registration_status.rb
+++ b/db/migrate/20200114171405_drop_webinar_users_registration_status.rb
@@ -3,4 +3,8 @@ class DropWebinarUsersRegistrationStatus < ActiveRecord::Migration[6.0]
   def up
     remove_column :webinar_users, :registration_status
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end


### PR DESCRIPTION
We are adding the Rails/ReversibleMigrationMethodDefinition cop to rubocop-discourse, this change resolves existing errors under this rule.