### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/components/modal/edit-webinar.gjs
+++ b/assets/javascripts/discourse/components/modal/edit-webinar.gjs
@@ -241,7 +241,7 @@ export default class EditWebinar extends Component {
                 <DButton
                   @action={{fn this.removePanelist panelist}}
                   class="remove-panelist-btn btn-danger"
-                  @icon="times"
+                  @icon="xmark"
                   @disabled={{this.loading}}
                 />
               </div>
@@ -291,7 +291,7 @@ export default class EditWebinar extends Component {
           <DButton
             @action={{this.resetVideoUrl}}
             class="new-panelist-btn btn-danger"
-            @icon="times"
+            @icon="xmark"
             @disabled={{this.canSaveVideoUrl}}
           />
         </div>

--- a/assets/javascripts/discourse/templates/components/remove-webinar-from-composer.hbs
+++ b/assets/javascripts/discourse/templates/components/remove-webinar-from-composer.hbs
@@ -9,7 +9,7 @@
     <DButton
       class="cancel no-text"
       @action={{action "removeWebinar"}}
-      @icon="times"
+      @icon="xmark"
       @title="zoom.remove"
     />
   </div>

--- a/assets/javascripts/discourse/templates/components/webinar-register.hbs
+++ b/assets/javascripts/discourse/templates/components/webinar-register.hbs
@@ -70,7 +70,7 @@
           @action={{action "register"}}
           class="webinar-register-button btn-primary"
           @label="zoom.register"
-          @icon="far-calendar-alt"
+          @icon="far-calendar-days"
           @disabled={{this.loading}}
         />
       {{/if}}


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.