### PR TITLE
DEV: Remove the legacy widget code

### DIFF
--- a/spec/system/topic_page_spec.rb
+++ b/spec/system/topic_page_spec.rb
@@ -1,20 +1,14 @@
 # frozen_string_literal: true
 
 describe "Discourse Zoom | Topic Page", type: :system do
-  %w[enabled disabled].each do |value|
-    before { SiteSetting.glimmer_post_stream_mode = value }
+  fab!(:topic) { Fabricate(:topic_with_op) }
+  fab!(:webinar) { Webinar.create(topic:, zoom_id: "123") }
 
-    context "when glimmer_post_stream_mode=#{value}" do
-      fab!(:topic) { Fabricate(:topic_with_op) }
-      fab!(:webinar) { Webinar.create(topic:, zoom_id: "123") }
+  before { SiteSetting.zoom_enabled = true }
 
-      before { SiteSetting.zoom_enabled = true }
-
-      it "renders successfully" do
-        visit "/t/#{topic.slug}/#{topic.id}"
-        expect(page).to have_css(".webinar-banner")
-        expect(page).to have_css("body.has-webinar")
-      end
-    end
+  it "renders successfully" do
+    visit "/t/#{topic.slug}/#{topic.id}"
+    expect(page).to have_css(".webinar-banner")
+    expect(page).to have_css("body.has-webinar")
   end
 end


### PR DESCRIPTION
Remove usages of `glimmer_post_stream_mode` in tests across various files, including acceptance and system-level specs, where it was used to toggle testing behavior. This reduces test complexity and ensures coverage without dependency on this feature flag, which is being phased out.