### PR TITLE
FIX: Ensure edit permission when attaching webinars

### DIFF
--- a/app/controllers/webinars_controller.rb
+++ b/app/controllers/webinars_controller.rb
@@ -84,8 +84,10 @@ module Zoom
     end
 
     def add_to_topic
-      topic = Topic.find(params[:topic_id])
+      topic = Topic.listable_topics.secured(guardian).find_by(id: params[:topic_id])
       raise Discourse::NotFound.new unless topic
+
+      guardian.ensure_can_edit!(topic)
 
       new_webinar =
         (

--- a/spec/requests/webinars_controller_spec.rb
+++ b/spec/requests/webinars_controller_spec.rb
@@ -301,6 +301,22 @@ describe Zoom::WebinarsController do
         expect(response.status).to eq(403)
       end
 
+      it "requires the user to be able to edit the topic" do
+        sign_in(other_user)
+
+        put(
+          "/zoom/t/#{other_topic.id}/webinars/nonzoom.json",
+          params: {
+            zoom_start_date: 3.days.ago,
+            zoom_title: "Fake webinar",
+          },
+        )
+
+        expect(response.status).to eq(403)
+        expect(response.parsed_body["error_type"]).to eq("invalid_access")
+        expect(other_topic.reload.webinar).to be_nil
+      end
+
       it "adds the webinar to the existing topic" do
         sign_in(user)
         expect(other_topic.webinar).to eq(nil)


### PR DESCRIPTION
## Summary

In `add_to_topic`, the target topic is now resolved through guardian-scoped visibility checks and `guardian.ensure_can_edit!` is enforced before a webinar can be attached, preventing users from adding webinars to topics they cannot edit.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1275

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>